### PR TITLE
Add Jules integration endpoint with TTS

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 flask
 faster-whisper
 requests
+gTTS


### PR DESCRIPTION
## Summary
- add `gTTS` dependency
- create `/transcribe_jules` endpoint
- send transcription to Jules API and return response with base64 audio

## Testing
- `python -m py_compile server.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_685ff57247a48331a0eb7fde9aefa930