### PR TITLE
feat: endpoint identify_med + vision deps

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ gTTS
 
 torch
 soundfile
+Pillow
+transformers


### PR DESCRIPTION
## Summary
- add Pillow and transformers dependencies
- load CLIP model and add product list
- implement `/identify_med` endpoint to classify medication images

## Testing
- `python3 -m py_compile server.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686257ecaca88331ab1d034d8e8d2743